### PR TITLE
Plantillas para mensajes

### DIFF
--- a/Automatizaciones/cambio_estado_puerta_mensaje_plantilla.yaml
+++ b/Automatizaciones/cambio_estado_puerta_mensaje_plantilla.yaml
@@ -1,0 +1,28 @@
+blueprint:
+    name: Cambio de estado de puerta
+    description: Avisar de que una puerta cambió de estado. Para usar es necesario cambiar la variable "sensores" a la lista de sensores de las puertas y "alarmado" a un ayudante booleano
+    domain: automation
+    author: cristianrguez8
+
+alias: Cambio de estado de puerta
+description: Avisar de que ya una puerta cambió de estado
+triggers:
+  - trigger: state
+    entity_id:
+        {{sensores}}
+    to:
+conditions:
+  - condition: state
+    entity_id: {{alarmado}}
+    state: "on"
+actions:
+    - service: script.enviar_notificacion_con_etiqueta
+      data:
+        titulo: >
+            {%- import 'mensajes.jinja' as mensajes -%}
+            {{ mensajes.mensajes_puertas('titulo', trigger.to_state.state, trigger.to_state.name) }}
+        mensaje: >
+            {%- import 'mensajes.jinja' as mensajes -%}
+            {{ mensajes.mensajes_puertas('mensaje', trigger.to_state.state, trigger.to_state.name) }}
+        etiqueta: "Alarmas"
+mode: single

--- a/Automatizaciones/detectado_movimiento_mensaje_plantilla.yaml
+++ b/Automatizaciones/detectado_movimiento_mensaje_plantilla.yaml
@@ -1,0 +1,28 @@
+blueprint:
+    name: Se ha detectado movimiento
+    description: Avisar de que se acaba de detectar movimiento. Para usar es necesario cambiar la variable "sensores" a la lista de sensores de las puertas y "alarmado" a un ayudante booleano
+    domain: automation
+    author: cristianrguez8
+
+alias: Se ha detectado movimiento
+description: ""
+triggers:
+  - trigger: state
+    entity_id:
+        {{sensores}}
+    not_to: 'off'
+conditions:
+  - condition: state
+    entity_id: {{alarmado}}
+    state: "on"
+actions:
+    - service: script.enviar_notificacion_con_etiqueta
+      data:
+        titulo: >
+            {%- import 'mensajes.jinja' as mensajes -%}
+            {{ mensajes.mensajes_movimiento('titulo', trigger.to_state.state, trigger.to_state.name) }}
+        mensaje: >
+            {%- import 'mensajes.jinja' as mensajes -%}
+            {{ mensajes.mensajes_movimiento('mensaje', trigger.to_state.state, trigger.to_state.name) }}
+        etiqueta: "Alarmas"
+mode: single

--- a/Automatizaciones/puerta_abierta_noche_mensaje_plantilla.yaml
+++ b/Automatizaciones/puerta_abierta_noche_mensaje_plantilla.yaml
@@ -1,0 +1,27 @@
+blueprint:
+    name: Puerta abierta por la noche
+    description: Comprobar que no te dejas una puerta abierta por la noche. Para usar es necesario cambiar la palabra "sensor_puerta" por una etiqueta que sólo tengan los sensores de las puertas
+    domain: automation
+    author: cristianrguez8
+
+alias: Puerta abierta por la noche
+description: Comprobar que no te dejas una puerta abierta por la noche
+triggers:
+  - trigger: time
+    at: "21:00:00"
+variables:
+    puertasAbiertas: "{{label_entities('sensor_puerta') | select('is_state', 'on') | list | map('state_attr', 'friendly_name') | list }}"
+    totalAbiertas: "{{puertasAbiertas | length }}"
+conditions: "{{ totalAbiertas > 0 }}"
+actions:
+    - service: script.enviar_notificacion_con_etiqueta
+      data:
+        titulo: >
+            {%- import 'mensajes.jinja' as mensajes -%}
+            {{ mensajes.mensajes_puertas_noche('titulo') }}
+        mensaje: >
+            {%- import 'mensajes.jinja' as mensajes -%}
+            {{ mensajes.mensajes_puertas_noche('mensaje', puertasAbiertas, totalAbiertas) }}
+        etiqueta: "Verificacion"
+mode: single
+

--- a/Automatizaciones/validacion_horaria_puertas_mensaje_plantilla.yaml
+++ b/Automatizaciones/validacion_horaria_puertas_mensaje_plantilla.yaml
@@ -1,0 +1,34 @@
+blueprint:
+  name: Validación horaria puertas
+  description: Validación horaria de que hay una o varias puertas abiertas dependiente de la alarma. Para usar es necesario cambiar la palabra "sensor_puerta" por una etiqueta que sólo tengan los sensores de las puertas y "alarmado" a un ayudante booleano
+  domain: automation
+  author: cristianrguez8
+
+alias: Validación horaria puertas
+description: Validación horaria de que hay una o varias puertas abiertas dependiente de la alarma
+triggers:
+  - trigger: time_pattern
+    hours: "*"
+variables:
+  puertasAbiertas: "{{label_entities('sensor_puerta') | select('is_state', 'on') | list | map('state_attr', 'friendly_name') | list }}"
+  totalAbiertas: "{{puertasAbiertas | length }}"
+conditions:
+  - and:
+    - "{{ totalAbiertas > 0 }}"
+    - condition: state
+    entity_id: {{alarmado}}
+      state: "on"
+    - condition: time
+      before: "23:05:00"
+      after: "07:50:00"
+actions:
+  - service: script.enviar_notificacion_con_etiqueta
+    data:
+      titulo: >
+            {%- import 'mensajes.jinja' as mensajes -%}
+            {{ mensajes.mensajes_val_puertas('titulo') }}
+      mensaje: >
+            {%- import 'mensajes.jinja' as mensajes -%}
+            {{ mensajes.mensajes_val_puertas('mensaje', puertasAbiertas, totalAbiertas) }}
+      etiqueta: "Verificacion"
+mode: single

--- a/Plantillas mensajes/buenos_dias.jinja
+++ b/Plantillas mensajes/buenos_dias.jinja
@@ -1,0 +1,88 @@
+{%- import 'mensajes_buenos_dias.jinja' as mensajes -%}
+
+{# Esta función te saludará indicando si ya amaneció o falta para ello #}
+{%- macro saludo() %}
+{{ mensajes.buenosDias() }}
+{%- if states.sun.sun.state == "above_horizon" -%}
+{{ mensajes.yaAmanecio() }}
+{%- else %}
+{%- set proximoAmanecer = as_timestamp(states.sensor.sun_next_rising.state) %}
+{%- set segundosHastaAmanecer = (proximoAmanecer-hoy) | round() %}
+{{ mensajes.tiempoRestanteAmanecer(segundosHastaAmanecer) }}
+{%- endif %}
+{%- endmacro %}
+
+{# Esta función utiliza 2 calendarios (festivos de tu CCAA y uno en el que anotes tus vacaciones) y el sensor de dia laboral #}
+{%- macro resumenDia() %}
+{%- set hoy = as_timestamp(now()) %}
+{{ mensajes.queDiaEs(hoy) }}
+{%- set esLaboral = states.binary_sensor.dia_laboral.state == 'on' -%}
+{# Define aquí el calendario de festivos de tu CCAA (puedes añadirlo en calendarios) #}
+{%- set esFestivo = states.calendar.espana_ga.state == 'on' -%}
+{%- set motivoFestivo = state_attr('calendar.espana_ga', 'message') -%}
+{# Y aquí el calendario en el que anotas tus vacaciones #}
+{%- set hayVacaciones = states.calendar.mis_vacaciones.state == 'on' -%}
+{%- if hayVacaciones -%}
+{{ mensajes.hoyHayVacaciones() }}
+{%- else -%}
+{%- if esLaboral -%}
+{%- if esFestivo -%}
+{{ mensajes.hoyEsFestivo(motivoFestivo) }}
+{%- else -%}
+{{ mensajes.hayQueTrabajar() }}
+{%- endif -%}
+{%- else -%}
+{{ mensajes.hoyEsNoLaboral() }}
+{%- if esFestivo -%}
+{{ mensajes.ademasEsFestivo(motivoFestivo) }}
+{%- endif -%}
+{%- endif -%}
+{%- if esFestivo != true -%}
+{%- set inicioFestivo = as_timestamp(state_attr('calendar.espana_ga','start_time')) %}
+{%- set diferenciaTiempo = (((inicioFestivo - hoy) / 86400)+1) | round() %}
+{{ mensajes.proximoFestivo(motivoFestivo, inicioFestivo, diferenciaTiempo) }}
+{%- endif %}
+{%- set inicioVacaciones = as_timestamp(state_attr('calendar.mis_vacaciones','start_time')) %}
+{%- set diferenciaTVacas = (((inicioVacaciones - hoy) / 86400)+1) | round() %}
+{{ mensajes.proximasVacaciones(inicioVacaciones, diferenciaTVacas) }}
+{%- endif %}
+{%- endmacro %}
+
+{# Esta función utiliza la integración del tiempo de aemet muestra un resumen del clima #}
+{%- macro resumenClima() %}
+{{ mensajes.separador() }}
+{%- set condicionActual = states.sensor.aemet_condition.state -%}
+{%- if condicionaActual != 'unavailable' -%}
+{%- set prediccionCondicion = states.sensor.aemet_daily_forecast_condition.state -%}
+{%- set prediccionProbLluvia = states.sensor.aemet_daily_forecast_precipitation_probability.state | int -%}
+{%- set prediccionTemperatura = states.sensor.aemet_daily_forecast_temperature.state | int -%}
+{%- set prediccionTempMin = states.sensor.aemet_daily_forecast_temperature_low.state | int -%}
+{%- set prediccionDireccionViento = states.sensor.aemet_daily_forecast_wind_bearing.state | int -%}
+{%- set prediccionVelocidadViento = states.sensor.aemet_daily_forecast_wind_speed.state %}
+{{ mensajes.elTiempoAhora(condicionActual) }}
+{{ mensajes.elTiempoPrediccion(prediccionCondicion) }}
+{{ mensajes.elTiempoPredProbLluvia(prediccionProbLluvia) }}
+{{ mensajes.elTiempoPredTemperaturas(prediccionTempMin, prediccionTemperatura) }}
+{{ mensajes.elTiempoPredVientos(prediccionDireccionViento, prediccionVelocidadViento) }}
+{%- else -%}
+{{ mensajes.elTiempoNoDisponible() }}
+{%- endif -%}
+{%- endmacro %}
+
+{# Esta función hace un resumen de los estados de sensores (por ejemplo temperatura interior y exterior) #}
+{%- macro resumenSensores() %}
+{{ mensajes.separador() }}
+{# Define aquí los sensores que quieres utilizar para el resumen #}
+{%- set tempInterior = states.sensor.temperatura_interior.state %}
+{%- set tempExterior = states.sensor.temperatura_exterior.state %}
+{%- set humedadInterior = states.sensor.humedad_interior.state %}
+{%- set humExterior = states.sensor.humedad_exterior.state %}
+{{ mensajes.resumenTemperaturas(tempInterior,tempExterior) }}
+{{ mensajes.resumenHumedades(humedadInterior,humExterior) }}
+{%- endmacro %}
+
+{# Esta función utiliza la integración de alertas de desastres GDACS y muestra si hay alguna #}
+{%- macro resumenAlertas() %}
+{%- set alertasDesastres = states.sensor.alertas_desastres.state | int %}
+{{ mensajes.alertaDesastres(alertasDesastres) }}
+{%- endmacro %}

--- a/Plantillas mensajes/formateadores.jinja
+++ b/Plantillas mensajes/formateadores.jinja
@@ -1,0 +1,51 @@
+{# Formatea un timestamp como dd/mm/YYYY #}
+{%- macro formatearFecha(timestamp) -%}
+{{ timestamp | timestamp_custom('%d/%m/%Y') }}
+{%- endmacro -%}
+
+{# Pásale una cantidad y te devolverá una 's' si es mayor que 1, útil para hacer plurales (por ejemplo gato{{pluralS(cantidadGatos)}} pintaría 'gatos' si es mayor que 1) #}
+{%- macro pluralS(i) -%}
+{%- if i != 1 %}s{% endif %}
+{%- endmacro -%}
+
+{# Pásale una cantidad y te devolverá una 'n' si es mayor que 1, útil para hacer plurales (por ejemplo queda{{pluralN(cantidad)}} pintaría 'quedan' si es mayor que 1) #}
+{%- macro pluralN(i) -%}
+{%- if i != 1 %}n{% endif %}
+{%- endmacro -%}
+
+{# Transforma el state de una entidad tipo clima a un texto que poder encadenar con 'Ahora mismo' #}
+{%- macro traducirClimaActual(clima) -%}
+{%- set climasActuales = {
+  'cloudy': 'está nublado',
+  'fog': 'hay niebla',
+  'rainy': 'está lloviendo',
+  'partlycloudy': 'hay nubes y claros',
+  'clearnight': 'está la noche clara',
+  'sunny': 'está el cielo despejado'
+} -%}
+{{ climasActuales.get(clima, 'no está claro el clima') }}
+{%- endmacro -%}
+
+{# Transforma el state de una entidad tipo clima a un texto que poder encadenar con 'Hoy se prevee' #}
+{%- macro traducirClimaPrediccion(clima) -%}
+{%- set prediccionesClima = {
+  'cloudy': ' que esté el cielo nublado',
+  'fog': ' que haya bancos de niebla',
+  'rainy': 'n lluvias',
+  'partlycloudy': ' que haya nubes y claros',
+  'clearnight': ' una noche clara',
+  'sunny': ' un día soleado'
+} -%}
+{{ prediccionesClima.get(clima, 'algo que no está claro') }}
+{%- endmacro -%}
+
+{# Convierte la dirección del viento en grados al punto cardinal desde el que se origina el viento #}
+{%- macro traducirDireccionViento(direccion) -%}
+{%- set direccionesViento = {
+  0: 'norte',
+  90: 'este',
+  180: 'sur',
+  270: 'oeste'
+} -%}
+{{ direccionesViento.get(direccion, direccion) }}
+{%- endmacro -%}

--- a/Plantillas mensajes/mensajes.jinja
+++ b/Plantillas mensajes/mensajes.jinja
@@ -1,0 +1,77 @@
+{# Estos mensajes se pueden usar para la automatización de cambio de estado de la puerta #}
+{%- macro mensajes_puertas(tipo, mensaje, puerta='puerta desconocida') -%}
+{%- set titulos = {
+  'on': 'Ojo cuidao!',
+  'off': 'Uf, menos mal'
+} -%}
+{%- set mensajes = {
+  'on': 'Se ha abierto',
+  'off': 'Ya se ha cerrado'
+} -%}
+{# On = se ha abierto, Off se ha cerrado #}
+{%- if tipo == 'titulo' -%}
+{# Si es otra situación va aquí debajo: #}
+{{ titulos.get(mensaje, 'Bueno carallo!') }}
+{%- else -%}
+{{ mensajes.get(mensaje, 'Ya se ha muerto') ~ ' ' ~ puerta }}
+{%- endif -%}
+{%- endmacro -%}
+
+{# Estos mensajes se pueden usar para la automatización de cambio de estado de sensores de movimiento #}
+{%- macro mensajes_movimiento(tipo, mensaje, sensor='desconocido') -%}
+{%- set titulos = {
+  'on': 'Intrusos!',
+  'off': 'Parece que se han marchado'
+} -%}
+{%- set mensajes = {
+  'on': 'ha detectado movimiento',
+  'off': 'ha pasado a despejado'
+} -%}
+{# On = hay alguien, Off no hay nadie #}
+{%- if tipo == 'titulo' -%}
+{# Si es otra situación va aquí debajo: #}
+{{ titulos.get(mensaje, 'Bueno carallo!') }}
+{%- else -%}
+{{ mensajes.get('intro', 'El sensor') ~ ' ' ~ sensor ~ ' ' ~  mensajes.get(mensaje, 'se ha muerto') }}
+{%- endif -%}
+{%- endmacro -%}
+
+{# Estos mensajes se pueden usar para la automatización que valida cada hora si hay puertas abiertas #}
+{%- macro mensajes_val_puertas(tipo, puertas=None, cantidad = 0) -%}
+{%- import 'formateadores.jinja' as formateadores -%}
+{# El título #}
+{%- if tipo == 'titulo' -%}
+Ten cuidado!
+{%- else -%}
+{# Y el mensaje que incluye la cantidad de puertas y el formateador que pinta los plurales #}
+Hay {{ cantidad }} puerta{{ formateadores.pluralS(cantidad) }} que permanece{{ formateadores.pluralN(cantidad) }} abierta{{ formateadores.pluralS(cantidad) }}:
+{%-if puertas is not none %}
+{# Y aquí se hace el bucle de las puertas abiertas #}
+{%- for puerta in puertas %}
+  {{ puerta }}
+{%- endfor %}
+{%- else %}
+  A saber
+{%- endif %}
+{%- endif -%}
+{%- endmacro -%}
+
+{# Estos mensajes se pueden usar para la automatización que comprueba a la noche si se queda alguna puerta abierta #}
+{%- macro mensajes_puertas_noche(tipo, puertas=None, cantidad = 0) -%}
+{%- import 'formateadores.jinja' as formateadores -%}
+{%- if tipo == 'titulo' -%}
+{# El título #}
+Cuidado!
+{%- else -%}
+{# Y el mensaje que incluye la cantidad de puertas y el formateador que pinta los plurales #}
+Se hace de noche y te has dejado {{ cantidad }} puerta{{ formateadores.pluralS(cantidad) }} abierta{{ formateadores.pluralS(cantidad) }}:
+{%-if puertas is not none %}
+{# Y aquí se hace el bucle de las puertas abiertas #}
+{%- for puerta in puertas %}
+  {{ puerta }}
+{%- endfor %}
+{%- else %}
+  A saber
+{%- endif %}
+{%- endif -%}
+{%- endmacro -%}

--- a/Plantillas mensajes/mensajes_buenos_dias.jinja
+++ b/Plantillas mensajes/mensajes_buenos_dias.jinja
@@ -1,0 +1,125 @@
+{# Un simple saludo de buenos días, perfecto para comenzar #}
+{%- macro buenosDias() %}
+Buenos días
+{%- endmacro %}
+
+{# Cuando ya amaneció te anima a levantarte #}
+{%- macro yaAmanecio() %}
+Venga que ya amaneció
+{%- endmacro %}
+
+{# Indica cuánto falta para que amanezca #}
+{%- macro tiempoRestanteAmanecer(segundos) %}
+{%- import 'formateadores.jinja' as formateadores -%}
+{%- if segundos < 60 -%}
+Queda{{ formateadores.pluralN(segundos) }} {{ segundos }} segundo{{ formateadores.pluralS(segundos) }} para que amanezca
+{%- elif segundos < 3600 -%}
+Queda{{ formateadores.pluralN((segundos/60) | round()) }} {{ (segundos/60) | round() }} minuto{{ formateadores.pluralS((segundos/60) | round()) }} para que amanezca
+{%- else -%}
+Queda{{ formateadores.pluralN((segundos/3600) | round()) }} {{ (segundos/3600) | round() }} hora{{ formateadores.pluralS((segundos/3600) | round()) }} para que amanezca 
+{%- endif %}
+{%- endmacro %}
+
+{# Muestra la fecha de hoy #}
+{%- macro queDiaEs(hoy) %}
+{%- import 'formateadores.jinja' as formateadores -%}
+Hoy es {{ formateadores.formatearFecha(hoy) }}
+{%- endmacro %}
+
+{# Te dice que hay vacaciones hoy #}
+{%- macro hoyHayVacaciones() %}
+Hoy hay vacaciones, ya era hora
+{%- endmacro %}
+
+{# Te dice que había que aunque es laboral es festivo (y el motivo del festivo) #}
+{%- macro hoyEsFestivo(motivo) %}
+Hoy había que trabajar pero es festivo por {{ motivo }}, yey!
+{%- endmacro %}
+
+{# Es un día laboral y toca trabajar #}
+{%- macro hayQueTrabajar() %}
+Por desgracia hay que trabajar hoy
+{%- endmacro %}
+
+{# No es laboral, así que no se trabaja #}
+{%- macro hoyEsNoLaboral() %}
+Hoy no se trabaja, es un gran día
+{%- endmacro %}
+
+{# Para agregar cuando es festivo (con el motivo del festivo) #}
+{%- macro ademasEsFestivo(motivo) %}
+Y además es festivo por {{ motivo }} y todo
+{%- endmacro %}
+
+{# Cuánto queda para el próximo festivo (con el motivo del festivo) #}
+{%- macro proximoFestivo(motivo, inicio, diferencia) %}
+{%- import 'formateadores.jinja' as formateadores -%}
+El próximo festivo es {{ motivo }} el día {{ formateadores.formatearFecha(inicio) }}
+Falta{{ formateadores.pluralN(diferencia) }} {{ diferencia }} día{{ formateadores.pluralS(diferencia) }}
+{%- endmacro %}
+
+{# Cuánto queda para el próximo día de vacaciones #}
+{%- macro proximasVacaciones(inicio, diferencia) %}
+{%- import 'formateadores.jinja' as formateadores -%}
+Las vacaciones empiezan el día {{ formateadores.formatearFecha(inicio) }}
+Ya sólo falta{{ formateadores.pluralN(diferencia) }} {{ diferencia }} día{{ formateadores.pluralS(diferencia) }}, ánimo
+{%- endmacro %}
+
+{# El tiempo ahora mismo #}
+{%- macro elTiempoAhora(clima) %}
+{%- import 'formateadores.jinja' as formateadores -%}
+Ahora mismo {{ formateadores.traducirClimaActual(clima) }}
+{%- endmacro %}
+
+{# La previsión del tiempo #}
+{%- macro elTiempoPrediccion(clima) %}
+{%- import 'formateadores.jinja' as formateadores -%}
+Hoy se prevee{{ formateadores.traducirClimaPrediccion(clima) }}
+{%- endmacro %}
+
+{# La previsión de la probabilidad de lluvias #}
+{%- macro elTiempoPredProbLluvia(probabilidad) %}
+{%- if probabilidad > 0 -%}
+La probabilidad de lluvias hoy es un {{ probabilidad }}%
+{%- endif -%}
+{%- endmacro -%}
+
+{# La previsión de las temperaturas #}
+{%- macro elTiempoPredTemperaturas(tMin, temperatura) -%}
+Con temperaturas de {{ temperatura }}º y mínimas de {{ tMin }}º
+{%- endmacro %}
+
+{# La previsión de los vientos #}
+{%- macro elTiempoPredVientos(direccion, velocidad) %}
+{%- import 'formateadores.jinja' as formateadores -%}
+{%- if direccion != 'unknown' -%}
+Con vientos del {{ formateadores.traducirDireccionViento(direccion) }} y velocidades de {{ velocidad }} km/h
+{%- endif -%}
+{%- endmacro %}
+
+{# Para cuando no funciona la integración del clima #}
+{%- macro elTiempoNoDisponible() %}
+La información climatológica no se encuentra disponible
+{%- endmacro %}
+
+{# La temperatura interior y exterior (cambia las variables o añade más si quieres más información, por ejemplo, arriba, en el bajo, en la habitación...) #}
+{%- macro resumenTemperaturas(interior,exterior) -%}
+Ahora mismo hace {{interior}}º dentro y {{exterior}}º fuera.
+{%- endmacro -%}
+
+{# La humedad relativa interior y exterior (cambia las variables o añade más si quieres más información, por ejemplo, arriba, en el bajo, en la habitación...) #}
+{%- macro resumenHumedades(interior,exterior) -%}
+La humedad relativa está en un {{interior}}% dentro y {{exterior}}% fuera.
+{%- endmacro -%}
+
+{# Te avisa de qué hay alertas de desastres (sólo si hay) #}
+{%- macro alertaDesastres(cantidad) %}
+{%- if cantidad > 0 -%}
+Alerta! Se han detectado {{alertasDesastres}} alertas de desastres
+{%- endif -%}
+{%- endmacro -%}
+
+{# Un separador muy útil cuando tienes mucho texto #}
+{%- macro separador() %}
+----------------------------------------------------------------
+{%- endmacro -%}


### PR DESCRIPTION
Se añaden automatizaciones que emplean plantillas de mensajes (se duplican las antiguas para poder ofrecer ambas versiones)
Se añaden varias plantillas, tanto para usar en las automatizaciones como para montar una automatización que te dé los buenos días y te haga un resumen del día
Se añaden también en una plantilla varios formateadores útiles para facilitar algunas cosas (por ejemplo poner S a las palabras en plural cuando hace falta)